### PR TITLE
Fix %7D in contributor links

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -168,7 +168,7 @@ BBBBBBBBBBBBBBBBB     aaaaaaaaaa  aaaa sssssssssss        eeeeeeeeeeeeee     ddd
     <ul class="flex gap-4 flex-wrap justify-center max-w-xs">
         {#each contributors as { username, id }}
             <li>
-                <a href={`https://github.com/${username}}`} target="_blank">
+                <a href={`https://github.com/${username}`} target="_blank">
                     <img
                         src={`https://avatars.githubusercontent.com/u/${id}?v=4`}
                         alt={`${username}\'s GitHub profile picture`}


### PR DESCRIPTION
Fixes contributor links on the main page
![image](https://github.com/coppinger/basedkit-website/assets/20638/3a518482-9605-4609-bceb-09c923f6f295)
